### PR TITLE
Removed quotes from NotImplementedError(reason)

### DIFF
--- a/examples/DuplexCallback/controller.py
+++ b/examples/DuplexCallback/controller.py
@@ -75,7 +75,7 @@ class Controller:
             # .value()  # read input.
             # .irq()    # (ESP8266/ESP32 only) ref to the irq function of real pin object.
         '''
-        raise NotImplementedError('reason')
+        raise NotImplementedError(reason)
         
 
     def prepare_irq_pin(self, pin_id):
@@ -84,14 +84,14 @@ class Controller:
             # .set_handler_for_irq_on_rising_edge()  # to set trigger and handler.
             # .detach_irq()
         '''
-        raise NotImplementedError('reason')
+        raise NotImplementedError(reason)
         
         
     def get_spi(self): 
         reason = '''
             # initialize SPI interface 
         '''
-        raise NotImplementedError('reason')  
+        raise NotImplementedError(reason)
         
         
     def prepare_spi(self, spi): 
@@ -100,7 +100,7 @@ class Controller:
             # .close()
             # .transfer(pin_ss, address, value = 0x00) 
         '''
-        raise NotImplementedError('reason')        
+        raise NotImplementedError(reason)
 
 
     def led_on(self, on = True):


### PR DESCRIPTION
Before:
>>> controller.Controller()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'Controller'
>>> controller = Controller()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 34, in __init__
  File "<stdin>", line 78, in prepare_pin
NotImplementedError: reason

After:
>>> controller = Controller()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 34, in __init__
  File "<stdin>", line 78, in prepare_pin
NotImplementedError:
            # a pin should provide:
            # .pin_id
            # .low()
            # .high()
            # .value()  # read input.
            # .irq()    # (ESP8266/ESP32 only) ref to the irq function of real pin object.