### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    ["sx127x.py", "github:Wei1234c/SX127x_driver_for_MicroPython_on_ESP8266/codes/sx127x/sx127x.py"],
+    ["controller_esp.py", "github:Wei1234c/SX127x_driver_for_MicroPython_on_ESP8266/codes/controller/controller_esp.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install the SX127x LoRa driver modules for MicroPython on ESP8266.